### PR TITLE
fix: check if Sound exists before closing in order to avoid panic

### DIFF
--- a/internal/motion/motion_manager.go
+++ b/internal/motion/motion_manager.go
@@ -45,7 +45,9 @@ func (mm *MotionManager) Close(id int) {
 	if index == -1 {
 		return
 	}
-	mm.queue[index].motion.LoadedSound.Close()
+	if mm.queue[index].motion.Sound != "" {
+		mm.queue[index].motion.LoadedSound.Close()
+	}
 	mm.queue = append(mm.queue[:index], mm.queue[index+1:]...)
 }
 


### PR DESCRIPTION
 A panic occurs when attempting to play a motion that has no associated sound data. 
 
Can be recreated using a free Hiyori Momose live2d model and executing `model.PlayMotion("Idle", 0, false)`